### PR TITLE
heroku error 👉 guest.rb : belongs_to :event (in line 2)

### DIFF
--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -1,5 +1,5 @@
 class Guest < ApplicationRecord
-  belongs_to :event, through: :user
+  belongs_to :event
   validates :email, presence: true, uniqueness: true
   validates :first_name, presence: true
   validates :last_name, presence: true


### PR DESCRIPTION
heroku error solution: 
# guest.rb
class Guest < ApplicationRecord
  belongs_to :event     # through... has been removed